### PR TITLE
update @mytonswap/widget dependency to version 2.0.7 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "cypress:open": "cypress open"
     },
     "dependencies": {
-        "@mytonswap/widget": "^2.0.1",
+        "@mytonswap/widget": "^2.0.7",
         "@tonconnect/ui-react": "^2.0.9",
         "clsx": "^2.1.1",
         "framer-motion": "^11.11.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@mytonswap/widget':
-        specifier: ^2.0.1
-        version: 2.0.1(@mytonswap/sdk@1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))
+        specifier: ^2.0.7
+        version: 2.0.7(@mytonswap/sdk@1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))
       '@tonconnect/ui-react':
         specifier: ^2.0.9
         version: 2.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -353,8 +353,8 @@ packages:
       '@ton/ton': ^15.0.0
       typescript: ^5.0.0
 
-  '@mytonswap/widget@2.0.1':
-    resolution: {integrity: sha512-llO0GxtR5CgFa4oSDfL+m93tvH4TjbuDFVdFU9sAUcdvqBTdQa+bljxFsgF3UroeWcSfN52JOCT1lHd79MOGIQ==}
+  '@mytonswap/widget@2.0.7':
+    resolution: {integrity: sha512-Er0ebb/c8ukALHDXUzX+aksAaycPghM3pMP+BmkegqVPnq9g/yu4662RRa8fZ+AuSGR3cCgcN8+9a2V2j5mmlg==}
     peerDependencies:
       '@mytonswap/sdk': ^1.0.9
       '@ton/ton': ^15.0.0
@@ -2707,7 +2707,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@mytonswap/widget@2.0.1(@mytonswap/sdk@1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))':
+  '@mytonswap/widget@2.0.7(@mytonswap/sdk@1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))':
     dependencies:
       '@mytonswap/sdk': 1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3)
       '@r2wc/react-to-web-component': 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -8,6 +8,8 @@
     --border-color: #f4f4f5;
     --primary-color: #22c55e;
     --background-color: #ffffff;
+    --swap-container-background: #f4f4f500;
+    --swap-container-border-color: #ffffff00;
     --input-card-color: #ffffff;
     --input-token-color: #f4f4f5;
     --light-shade-color: #f4f4f5;
@@ -22,6 +24,8 @@
 .dark:root {
     --border-color: #1d2939;
     --primary-color: #16a34a;
+    --swap-container-background: #f4f4f500;
+    --swap-container-border-color: #ffffff00;
     --background-color: #101828;
     --input-card-color: #344054;
     --input-token-color: #101828;


### PR DESCRIPTION
This pull request includes updates to dependencies and styling changes. The most important changes include updating the `@mytonswap/widget` dependency to version 2.0.7 and adding new CSS variables for swap container styling.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15): Updated the `@mytonswap/widget` dependency from version 2.0.1 to 2.0.7.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13): Updated the `@mytonswap/widget` dependency specification and version to 2.0.7 in multiple sections, including `importers`, `packages`, and `snapshots`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL356-R357) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2710-R2710)

Styling changes:

* [`src/styles/index.css`](diffhunk://#diff-c1c322616098d4351e10768cd3ad654e2b79fcf30cff1606ff4e79b7893fbe5bR11-R12): Added new CSS variables `--swap-container-background` and `--swap-container-border-color` for both light and dark themes. [[1]](diffhunk://#diff-c1c322616098d4351e10768cd3ad654e2b79fcf30cff1606ff4e79b7893fbe5bR11-R12) [[2]](diffhunk://#diff-c1c322616098d4351e10768cd3ad654e2b79fcf30cff1606ff4e79b7893fbe5bR27-R28)