### PR TITLE
Update widget to version 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "cypress:open": "cypress open"
     },
     "dependencies": {
-        "@mytonswap/widget": "^2.0.7",
+        "@mytonswap/widget": "^2.0.9",
         "@tonconnect/ui-react": "^2.0.9",
         "clsx": "^2.1.1",
         "framer-motion": "^11.11.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@mytonswap/widget':
-        specifier: ^2.0.7
-        version: 2.0.7(@mytonswap/sdk@1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))
+        specifier: ^2.0.9
+        version: 2.0.9(@mytonswap/sdk@1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))
       '@tonconnect/ui-react':
         specifier: ^2.0.9
         version: 2.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -353,8 +353,8 @@ packages:
       '@ton/ton': ^15.0.0
       typescript: ^5.0.0
 
-  '@mytonswap/widget@2.0.7':
-    resolution: {integrity: sha512-Er0ebb/c8ukALHDXUzX+aksAaycPghM3pMP+BmkegqVPnq9g/yu4662RRa8fZ+AuSGR3cCgcN8+9a2V2j5mmlg==}
+  '@mytonswap/widget@2.0.9':
+    resolution: {integrity: sha512-F3Abw35x1jd43VWiXeMWdWEqcWQtsNVkBFcuWcNQD639oUO4LsUffjAu54f12plM52rGg4SqvcdgeyPmJ/MzEQ==}
     peerDependencies:
       '@mytonswap/sdk': ^1.0.9
       '@ton/ton': ^15.0.0
@@ -2707,7 +2707,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@mytonswap/widget@2.0.7(@mytonswap/sdk@1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))':
+  '@mytonswap/widget@2.0.9(@mytonswap/sdk@1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))':
     dependencies:
       '@mytonswap/sdk': 1.0.10(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3)
       '@r2wc/react-to-web-component': 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -5,14 +5,20 @@
 @tailwind utilities;
 
 .light:root {
-    --border-color: #dadada;
+    --border-color: #f4f4f5;
     --primary-color: #22c55e;
+    --secondary-color: #ebebeb;
     --background-color: #ffffff;
-    --swap-container-background: #f4f4f500;
-    --swap-container-border-color: #ffffff00;
+    --modal-background-color: #ffffff;
+    --swap-container-background: #f4f4f5;
+    --swap-container-border-color: #ffffff;
     --input-card-color: #ffffff;
-    --input-token-color: #f0f0f0;
-    --light-shade-color: #f0f0f0;
+    --input-card-pay-color: #ffffff;
+    --input-card-receive-color: #d0d5dd;
+    --input-token-color: #f4f4f5;
+    --change-direction-background-color: #22c55e;
+    --change-direction-icon-color: #f4f4f5;
+    --light-shade-color: #f4f4f5;
     --slippage-box-color: #71717a;
     --text-black-color: #000000;
     --text-white-color: #ffffff;
@@ -24,13 +30,19 @@
 .dark:root {
     --border-color: #1d2939;
     --primary-color: #16a34a;
+    --secondary-color: #283241;
     --background-color: #101828;
+    --modal-background-color: #101828;
     --swap-container-background-color: #101828;
     --swap-container-border-color: #1d293900;
+    --input-card-pay-color: #09090b;
+    --input-card-receive-color: #344054;
     --input-card-color: #101828;
     --input-token-color: #1d2939;
+    --change-direction-background-color: #101828;
+    --change-direction-icon-color: #16a34a;
     --light-shade-color: #1d2939;
-    --slippage-box-color: #3d4557;
+    --slippage-box-color: #101828;
     --text-black-color: #ffffff;
     --text-white-color: #ffffff;
     --text-fade-color: #6b7280;


### PR DESCRIPTION
This pull request includes updates to dependencies and changes to CSS styles. The most important changes include upgrading the `@mytonswap/widget` dependency and adding new CSS variables for improved theming.

Dependency updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R15): Upgraded `@mytonswap/widget` from version `2.0.7` to `2.0.9`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13): Updated the version specification and resolution integrity for `@mytonswap/widget` to `2.0.9`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12-R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL356-R357) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2710-R2710)

CSS style changes:
* [`src/styles/index.css`](diffhunk://#diff-c1c322616098d4351e10768cd3ad654e2b79fcf30cff1606ff4e79b7893fbe5bL8-R21): Added new CSS variables for both light and dark themes, including `--secondary-color`, `--modal-background-color`, `--input-card-pay-color`, `--input-card-receive-color`, `--change-direction-background-color`, and `--change-direction-icon-color`. Updated existing color values for better contrast and consistency. [[1]](diffhunk://#diff-c1c322616098d4351e10768cd3ad654e2b79fcf30cff1606ff4e79b7893fbe5bL8-R21) [[2]](diffhunk://#diff-c1c322616098d4351e10768cd3ad654e2b79fcf30cff1606ff4e79b7893fbe5bR33-R45)