### PR TITLE
update widget to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@mytonswap/sdk": "^1.0.12",
-        "@mytonswap/widget": "^2.0.22",
+        "@mytonswap/widget": "^2.0.24",
         "@tonconnect/ui-react": "^2.0.9",
         "axios": "^1.7.8",
         "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@mytonswap/sdk": "^1.0.12",
-        "@mytonswap/widget": "^2.0.21",
+        "@mytonswap/widget": "^2.0.22",
         "@tonconnect/ui-react": "^2.0.9",
         "axios": "^1.7.8",
         "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.12
         version: 1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3)
       '@mytonswap/widget':
-        specifier: ^2.0.22
-        version: 2.0.22(@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))
+        specifier: ^2.0.24
+        version: 2.0.24(@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))
       '@tonconnect/ui-react':
         specifier: ^2.0.9
         version: 2.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -368,8 +368,8 @@ packages:
       '@ton/ton': ^15.0.0
       typescript: ^5.0.0
 
-  '@mytonswap/widget@2.0.22':
-    resolution: {integrity: sha512-t1NKHqDO/ulkRD7tuINS8s77wbOes5HR289qvW35e3TN/YaRLMmZ8NNU3opAKWpy43ZVjWY7tioH2anYElR9QQ==}
+  '@mytonswap/widget@2.0.24':
+    resolution: {integrity: sha512-QkbWMSiufSDjUzRHdcSBuvBIVaNJVWEmCdpyL+GmeyppeqVx+ZpM7Mof2YAdcS39yfW8FxLSZDLXXYw8iREccw==}
     peerDependencies:
       '@mytonswap/sdk': ^1.0.12
       '@ton/ton': ^15.0.0
@@ -2735,7 +2735,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@mytonswap/widget@2.0.22(@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))':
+  '@mytonswap/widget@2.0.24(@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))':
     dependencies:
       '@mytonswap/sdk': 1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3)
       '@r2wc/react-to-web-component': 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.12
         version: 1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3)
       '@mytonswap/widget':
-        specifier: ^2.0.21
-        version: 2.0.21(@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))
+        specifier: ^2.0.22
+        version: 2.0.22(@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))
       '@tonconnect/ui-react':
         specifier: ^2.0.9
         version: 2.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -368,8 +368,8 @@ packages:
       '@ton/ton': ^15.0.0
       typescript: ^5.0.0
 
-  '@mytonswap/widget@2.0.21':
-    resolution: {integrity: sha512-nrvt2Y4tywp6yRtU4Kj0bSfhBG4KJpZpjgEoql//I7SEluzJUSHmBOsJpopmTxu9LDyy2KFVZwWylWw4vM+X+g==}
+  '@mytonswap/widget@2.0.22':
+    resolution: {integrity: sha512-t1NKHqDO/ulkRD7tuINS8s77wbOes5HR289qvW35e3TN/YaRLMmZ8NNU3opAKWpy43ZVjWY7tioH2anYElR9QQ==}
     peerDependencies:
       '@mytonswap/sdk': ^1.0.12
       '@ton/ton': ^15.0.0
@@ -2735,7 +2735,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@mytonswap/widget@2.0.21(@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))':
+  '@mytonswap/widget@2.0.22(@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3))(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(@types/react@18.3.12)(clsx@2.1.1)(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.4)(vite@5.4.10(@types/node@22.9.0))':
     dependencies:
       '@mytonswap/sdk': 1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.3)
       '@r2wc/react-to-web-component': 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
This pull request includes updates to the `@mytonswap/widget` dependency across multiple files to ensure compatibility with the latest version.

Dependency update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R17): Updated the version of `@mytonswap/widget` from `^2.0.22` to `^2.0.24`.

Corresponding updates in `pnpm-lock.yaml`:

* [`importers`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15-R16): Updated the specifier and version of `@mytonswap/widget` to `^2.0.24` and `2.0.24`, respectively.
* [`packages`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL371-R372): Updated the resolution integrity hash for `@mytonswap/widget@2.0.24`.
* [`snapshots`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2738-R2738): Updated the entry for `@mytonswap/widget` to reflect the new version `2.0.24`.